### PR TITLE
Updated module.json for v10

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -1,16 +1,19 @@
 {
-  "name": "foundry-filepicker-favorites",
+  "id": "foundry-filepicker-favorites",
   "title": "Filepicker Improvements",
   "description": "A simple module to add favorite directories and a search to the file picker",
   "version": "1.2.5",
-  "author": "manuel-hegner",
-  /*"authors": [
+  "compatibility": {
+    "minimum": "10",
+    "verified": "10.291",
+    "maximum": "10"
+  },
+  "authors": [
     {
-      "name": "",
-      "email": "",
-      "url": ""
+      "name": "manuel-hegner",
+      "flags": {}
     }
-  ],*/
+  ],
   "scripts": [],
   "esmodules": [
     "foundry-filepicker-favorites.js"
@@ -18,15 +21,17 @@
   "styles": [
     "foundry-filepicker-favorites.css"
   ],
-  "dependencies": [
-    {
-      "name": "lib-wrapper"
-    }
-  ],
+  "relationships": {
+    "requires": [
+      {
+        "id": "lib-wrapper",
+        "type": "module",
+        "compatibility": {}
+      }
+    ]
+  },
   "packs": [],
   "languages": [],
-  "minimumCoreVersion": "0.8.9",
-  "compatibleCoreVersion": "V9",
   "url": "https://github.com/manuel-hegner/foundry-filepicker-favorites",
   "manifest": "https://github.com/manuel-hegner/foundry-filepicker-favorites/releases/latest/download/module.json",
   "download": "https://github.com/manuel-hegner/foundry-filepicker-favorites/releases/download/v1.2.5/foundry-filepicker-favorites-v1.2.5.zip",


### PR DESCRIPTION
This removes the warnings for using deprecated entries such as author, dependancies, name, and compatible core versions